### PR TITLE
Fixes #39 - Add description for tasks

### DIFF
--- a/src/main/kotlin/se/premex/OwnershipPlugin.kt
+++ b/src/main/kotlin/se/premex/OwnershipPlugin.kt
@@ -19,6 +19,9 @@ class OwnershipPlugin : Plugin<Project> {
                 ValidateOwnershipTask::class.java
             ) { task ->
                 task.ownershipExtension = ownershipExtension
+
+                task.group = "Ownership"
+                task.description = "Validate the content in OWNERSHIP.toml configuration files"
             }
 
             if (target == target.rootProject) {
@@ -27,6 +30,8 @@ class OwnershipPlugin : Plugin<Project> {
                     GenerateOwnershipTask::class.java
                 ) { task ->
                     task.ownershipExtension = ownershipExtension
+                    task.group = "Ownership"
+                    task.description = "Generates the supported and configured VCS OWNERSHIP files"
                 }.configure {
                     it.dependsOn(validateOwnershipTask)
                 }

--- a/src/test/kotlin/se/premex/FixtureTaskTest.kt
+++ b/src/test/kotlin/se/premex/FixtureTaskTest.kt
@@ -1,0 +1,49 @@
+package se.premex
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.io.File
+
+private val fixturesDir = File("src/test/fixtures")
+
+class FixtureTaskTest {
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "singlemodule",
+            "multimodule",
+            "singlemodule_multi_ownerships",
+        ]
+    )
+    fun checkDescriptionOfTasks(input: String) {
+        val fixtureDir = File(fixturesDir, input)
+
+        val result = createRunner(fixtureDir).build()
+
+        assertThat(result.output).contains(
+            """
+            |Ownership tasks
+            |---------------
+            |generateOwnership - Generates the supported and configured VCS OWNERSHIP files
+            |validateOwnership - Validate the content in OWNERSHIP.toml configuration files
+            |""".trimMargin()
+        )
+    }
+
+    private fun createRunner(fixtureDir: File): GradleRunner {
+        val gradleRoot = File(fixtureDir, "gradle").also { it.mkdir() }
+        File("gradle/wrapper").copyRecursively(File(gradleRoot, "wrapper"), true)
+        return GradleRunner.create()
+            .withProjectDir(fixtureDir)
+            .withDebug(true) // Run in-process
+            .withArguments(
+                "clean",
+                "tasks"
+            )
+            .withPluginClasspath()
+            .forwardOutput()
+    }
+}


### PR DESCRIPTION
Ownership tasks
---------------
generateOwnership - Generates the supported and configured VCS OWNERSHIP files
validateOwnership - Validate the content in OWNERSHIP.toml configuration files